### PR TITLE
feat: Expanded checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 build/
 dist/
 *.egg-info/
+.pytest_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+exclude: 'tests\/b.*$'
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 19.3b0
+    hooks:
+      - id: black
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v1.4.0
+    hooks:
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-xml
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: debug-statements
+      - id: flake8
+      - id: fix-encoding-pragma
+        args: ["--remove"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
     - /^\d[\d.]+$/
 
 install:
-  - pip install -e .
+  - pip install -e .[test]
 
 script:
   - make build

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,22 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+The MIT License (MIT)
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2019 Functional Software, Inc. dba Sentry
+Copyright (c) 2016 Łukasz Langa
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 all: build
 
 lint:
-	true
+	flake8
 
 test:
-	true
+	py.test
 
 build: clean test lint
 	python setup.py sdist bdist_wheel --universal > /dev/null

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/sentry-flake8.svg)](https://pypi.org/project/sentry-flake8)
 [![Travis](https://img.shields.io/travis/com/getsentry/sentry-flake8.svg)](https://travis-ci.com/getsentry/sentry-flake8)
 
-
 Sentry's custom flake8 checker plugin.
-
 
 ## Install
 
@@ -17,3 +15,7 @@ No further configuration is necessary for `flake8` to load the plugin. An exampl
 $ flake8 --version
 3.5.0 (mccabe: 0.6.1, pycodestyle: 2.3.1, pyflakes: 1.6.0, sentry-flake8: 0.0.1) CPython 2.7.15 on Darwin
 ```
+
+## Credits
+
+This extension is inspired by, and based upon work done by Łukasz Langa in [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear).

--- a/sentry_check.py
+++ b/sentry_check.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import
 
 import ast
-import pycodestyle
-
 from collections import namedtuple
 from functools import partial
 
+import pycodestyle
+
 __version__ = "0.0.1"
+
 
 class SentryVisitor(ast.NodeVisitor):
     NODE_WINDOW_SIZE = 4
@@ -22,14 +23,12 @@ class SentryVisitor(ast.NodeVisitor):
 
     def finish(self):
         if not self.has_absolute_import:
-            self.errors.append(
-                B003(1, 1),
-            )
+            self.errors.append(B102(1, 1))
 
     def visit(self, node):
         self.node_stack.append(node)
         self.node_window.append(node)
-        self.node_window = self.node_window[-self.NODE_WINDOW_SIZE:]
+        self.node_window = self.node_window[-self.NODE_WINDOW_SIZE :]
         super(SentryVisitor, self).visit(node)
         self.node_stack.pop()
 
@@ -38,89 +37,182 @@ class SentryVisitor(ast.NodeVisitor):
             self.errors.append(B001(node.lineno, node.col_offset))
         self.generic_visit(node)
 
+    def visit_UAdd(self, node):
+        trailing_nodes = list(map(type, self.node_window[-4:]))
+        if trailing_nodes == [ast.UnaryOp, ast.UAdd, ast.UnaryOp, ast.UAdd]:
+            originator = self.node_window[-4]
+            self.errors.append(B002(originator.lineno, originator.col_offset))
+        self.generic_visit(node)
+
     def visit_ImportFrom(self, node):
         if node.module in B307.names:
             self.errors.append(B307(node.lineno, node.col_offset))
 
-        if node.module == '__future__':
+        if node.module == "__future__":
             for nameproxy in node.names:
-                if nameproxy.name == 'absolute_import':
+                if nameproxy.name == "absolute_import":
                     self.has_absolute_import = True
                     break
 
     def visit_Import(self, node):
         for alias in node.names:
-            if alias.name.split('.', 1)[0] in B307.names:
+            if alias.name.split(".", 1)[0] in B307.names:
                 self.errors.append(B307(node.lineno, node.col_offset))
 
     def visit_Call(self, node):
         if isinstance(node.func, ast.Attribute):
             for bug in (B301, B302, B305):
                 if node.func.attr in bug.methods:
-                    call_path = '.'.join(self.compose_call_path(node.func.value))
+                    call_path = ".".join(self.compose_call_path(node.func.value))
                     if call_path not in bug.valid_paths:
                         self.errors.append(bug(node.lineno, node.col_offset))
                     break
-            for bug in (B312, ):
+            else:
+                self.check_for_b005(node)
+            for bug in (B312,):
                 if node.func.attr in bug.methods:
-                    call_path = '.'.join(self.compose_call_path(node.func.value))
+                    call_path = ".".join(self.compose_call_path(node.func.value))
                     if call_path in bug.invalid_paths:
                         self.errors.append(bug(node.lineno, node.col_offset))
                     break
+        else:
+            self.check_for_b004(node)
+            self.check_for_b009_b010(node)
         self.generic_visit(node)
+
+    def check_for_b004(self, node):
+        try:
+            if (
+                node.func.id in ("getattr", "hasattr")
+                and node.args[1].s == "__call__"  # noqa: W503
+            ):
+                self.errors.append(B004(node.lineno, node.col_offset))
+        except (AttributeError, IndexError):
+            pass
+
+    def check_for_b009_b010(self, node):
+        try:
+            if (
+                node.func.id == "getattr"
+                and len(node.args) == 2  # noqa: W503
+                and isinstance(node.args[1], ast.Str)  # noqa: W503
+            ):
+                self.errors.append(B009(node.lineno, node.col_offset))
+            elif (
+                node.func.id == "setattr"
+                and len(node.args) == 3  # noqa: W503
+                and isinstance(node.args[1], ast.Str)  # noqa: W503
+            ):
+                self.errors.append(B010(node.lineno, node.col_offset))
+        except (AttributeError, IndexError):
+            pass
 
     def visit_Attribute(self, node):
         call_path = list(self.compose_call_path(node))
-        if '.'.join(call_path) == 'sys.maxint':
+        if ".".join(call_path) == "sys.maxint":
             self.errors.append(B304(node.lineno, node.col_offset))
-        elif len(call_path) == 2 and call_path[1] == 'message':
+        elif len(call_path) == 2 and call_path[1] == "message":
             name = call_path[0]
             for elem in reversed(self.node_stack[:-1]):
-                if isinstance(elem, ast.ExceptHandler) and elem.name == name:
+                if isinstance(elem, ast.ExceptHandler) and elem.name.id == name:
                     self.errors.append(B306(node.lineno, node.col_offset))
                     break
 
         if node.attr in B101.methods:
-            self.errors.append(
-                B101(
-                    message="B101: Avoid using the {} mock call as it is "
-                    "confusing and prone to causing invalid test "
-                    "behavior.".format(node.attr),
-                    lineno=node.lineno,
-                    col=node.col_offset,
-                ),
-            )
+            self.errors.append(B101(node.lineno, node.col_offset, vars=(node.attr,)))
 
     def visit_Assign(self, node):
         # TODO(dcramer): pretty sure these aren't working correctly on Python2
         if isinstance(self.node_stack[-2], ast.ClassDef):
             # note: by hasattr belowe we're ignoring starred arguments, slices
             # and tuples for simplicity.
-            assign_targets = {t.id for t in node.targets if hasattr(t, 'id')}
-            if '__metaclass__' in assign_targets:
+            assign_targets = {t.id for t in node.targets if hasattr(t, "id")}
+            if "__metaclass__" in assign_targets:
                 self.errors.append(B303(node.lineno, node.col_offset))
-            if '__unicode__' in assign_targets:
+            if "__unicode__" in assign_targets:
                 self.errors.append(B313(node.lineno, node.col_offset))
+        elif len(node.targets) == 1:
+            t = node.targets[0]
+            if isinstance(t, ast.Attribute) and isinstance(t.value, ast.Name):
+                if (t.value.id, t.attr) == ("os", "environ"):
+                    self.errors.append(B003(node.lineno, node.col_offset))
+        self.generic_visit(node)
+
+    def visit_For(self, node):
+        self.check_for_b007(node)
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node):
+        # self.check_for_b902(node)
+        self.check_for_b006(node)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node):
+        # self.check_for_b901(node)
+        # self.check_for_b902(node)
+        self.check_for_b006(node)
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node):
+        # self.check_for_b903(node)
         self.generic_visit(node)
 
     def visit_Name(self, node):
         for bug in (B308, B309, B310, B311):
             if node.id in bug.names:
-                self.errors.append(
-                    bug(
-                        lineno=node.lineno,
-                        col=node.col_offset,
-                    ),
-                )
-        if node.id == 'print':
+                self.errors.append(bug(lineno=node.lineno, col=node.col_offset))
+        if node.id == "print":
             self.check_print(node)
 
     def visit_Print(self, node):
         self.check_print(node)
 
     def check_print(self, node):
-        if not self.filename.startswith('tests/'):
+        if not self.filename.startswith("tests/"):
             self.errors.append(B314(lineno=node.lineno, col=node.col_offset))
+
+    def check_for_b005(self, node):
+        if node.func.attr not in B005.methods:
+            return  # method name doesn't match
+
+        if len(node.args) != 1 or not isinstance(node.args[0], ast.Str):
+            return  # used arguments don't match the builtin strip
+
+        call_path = ".".join(self.compose_call_path(node.func.value))
+        if call_path in B005.valid_paths:
+            return  # path is exempt
+
+        s = node.args[0].s
+        if len(s) == 1:
+            return  # stripping just one character
+
+        if len(s) == len(set(s)):
+            return  # no characters appear more than once
+
+        self.errors.append(B005(node.lineno, node.col_offset))
+
+    def check_for_b006(self, node):
+        for default in node.args.defaults:
+            if isinstance(default, B006.mutable_literals):
+                self.errors.append(B006(default.lineno, default.col_offset))
+            elif isinstance(default, ast.Call):
+                call_path = ".".join(self.compose_call_path(default.func))
+                if call_path in B006.mutable_calls:
+                    self.errors.append(B006(default.lineno, default.col_offset))
+                elif call_path not in B008.immutable_calls:
+                    self.errors.append(B008(default.lineno, default.col_offset))
+
+    def check_for_b007(self, node):
+        targets = NameFinder()
+        targets.visit(node.target)
+        ctrl_names = set(filter(lambda s: not s.startswith("_"), targets.names))
+        body = NameFinder()
+        for expr in node.body:
+            body.visit(expr)
+        used_names = set(body.names)
+        for name in sorted(ctrl_names - used_names):
+            n = targets.names[name][0]
+            self.errors.append(B007(n.lineno, n.col_offset, vars=(name,)))
 
     def compose_call_path(self, node):
         if isinstance(node, ast.Attribute):
@@ -131,27 +223,45 @@ class SentryVisitor(ast.NodeVisitor):
             yield node.id
 
 
+class NameFinder(ast.NodeVisitor):
+    """Finds a name within a tree of nodes.
+    After `.visit(node)` is called, `found` is a dict with all name nodes inside,
+    key is name string, value is the node (useful for location purposes).
+    """
+
+    def __init__(self, names=None):
+        self.names = names or {}
+
+    def visit_Name(self, node):
+        self.names.setdefault(node.id, []).append(node)
+
+    def visit(self, node):
+        """Like super-visit but supports iteration over lists."""
+        if not isinstance(node, list):
+            return super(NameFinder, self).visit(node)
+
+        for elem in node:
+            super(NameFinder, self).visit(elem)
+        return node
+
+
 class SentryCheck(object):
-    name = 'sentry-flake8'
+    name = "sentry-flake8"
     version = __version__
 
-    def __init__(self, tree, filename=None, lines=None):
+    def __init__(self, tree=None, filename=None, lines=None, visitor=SentryVisitor):
         self.tree = tree
         self.filename = filename
         self.lines = lines
-        self.visitor = SentryVisitor
+        self.visitor = visitor
 
     def run(self):
         if not self.tree or not self.lines:
             self.load_file()
 
-        visitor = self.visitor(
-            filename=self.filename,
-            lines=self.lines,
-        )
+        visitor = self.visitor(filename=self.filename, lines=self.lines)
         visitor.visit(self.tree)
         visitor.finish()
-
         for e in visitor.errors:
             try:
                 if pycodestyle.noqa(self.lines[e.lineno - 1]):
@@ -159,7 +269,7 @@ class SentryCheck(object):
             except IndexError:
                 pass
 
-            yield e
+            yield self.adapt_error(e)
 
     def load_file(self):
         """
@@ -183,149 +293,186 @@ class SentryCheck(object):
     #     for code, lineno, name in visitor.errors:
     #         yield lineno, 0, self.codes[code], type(self)
 
+    @classmethod
+    def adapt_error(cls, e):
+        """Adapts the extended error namedtuple to be compatible with Flake8."""
+        return e._replace(message=e.message.format(*e.vars))[:4]
 
-error = namedtuple('error', 'lineno col message type')
 
-B001 = partial(
-    error,
-    message="B001: Do not use bare `except:`, it also catches unexpected "
+error = namedtuple("error", "lineno col message type vars")
+Error = partial(partial, error, message=u"", type=SentryCheck, vars=())
+
+B001 = Error(
+    message=u"B001: Do not use bare `except:`, it also catches unexpected "
     "events like memory errors, interrupts, system exit, and so on.  "
     "Prefer `except Exception:`.  If you're sure what you're doing, "
-    "be explicit and write `except BaseException:`.",
-    type=SentryCheck,
+    "be explicit and write `except BaseException:`."
 )
 
-B002 = partial(
-    error,
-    message="B002: Python does not support the unary prefix increment. Writing "
-    "++n is equivalent to +(+(n)), which equals n. You meant n += 1.",
-    type=SentryCheck,
+B002 = Error(
+    message=u"B002: Python does not support the unary prefix increment. Writing "
+    "++n is equivalent to +(+(n)), which equals n. You meant n += 1."
 )
 
-B003 = partial(
-    error,
-    message="B003: Missing `from __future__ import absolute_import`",
-    type=SentryCheck,
+B003 = Error(
+    message=u"B003: Assigning to `os.environ` doesn't clear the environment. "
+    "Subprocesses are going to see outdated variables, in disagreement "
+    "with the current process. Use `os.environ.clear()` or the `env=` "
+    "argument to Popen."
 )
 
-B101 = partial(error, type=SentryCheck)
-B101.methods = {
-    'assert_calls', 'assert_not_called', 'assert_called', 'assert_called_once', 'not_called',
-    'called_once', 'called_once_with'
+B004 = Error(
+    message=u"B004: Using `hasattr(x, '__call__')` to test if `x` is callable "
+    "is unreliable. If `x` implements custom `__getattr__` or its "
+    "`__call__` is itself not callable, you might get misleading "
+    "results. Use `callable(x)` for consistent results."
+)
+
+B005 = Error(
+    message=u"B005: Using .strip() with multi-character strings is misleading "
+    "the reader. It looks like stripping a substring. Move your "
+    "character set to a constant if this is deliberate. Use "
+    ".replace() or regular expressions to remove string fragments."
+)
+B005.methods = {"lstrip", "rstrip", "strip"}
+B005.valid_paths = {}
+
+B006 = Error(
+    message=u"B006: Do not use mutable data structures for argument defaults. "
+    "All calls reuse one instance of that data structure, persisting "
+    "changes between them."
+)
+B006.mutable_literals = (ast.Dict, ast.List, ast.Set)
+B006.mutable_calls = {
+    "Counter",
+    "OrderedDict",
+    "collections.Counter",
+    "collections.OrderedDict",
+    "collections.defaultdict",
+    "collections.deque",
+    "defaultdict",
+    "deque",
+    "dict",
+    "list",
+    "set",
 }
+B007 = Error(
+    message=u"B007: Loop control variable {!r} not used within the loop body. "
+    "If this is intended, start the name with an underscore."
+)
+B008 = Error(
+    message=u"B008: Do not perform calls in argument defaults. The call is "
+    "performed only once at function definition time. All calls to your "
+    "function will reuse the result of that definition-time call. If "
+    "this is intended, assign the function call to a module-level "
+    "variable and use that variable as a default value."
+)
+B008.immutable_calls = {"tuple", "frozenset"}
+B009 = Error(
+    message=u"B009: Do not call getattr with a constant attribute value, "
+    "it is not any safer than normal property access."
+)
+B010 = Error(
+    message=u"B010: Do not call setattr with a constant attribute value, "
+    "it is not any safer than normal property access."
+)
+
+B101 = Error(
+    message=u"B101: Avoid using the {} mock call as it is "
+    "confusing and prone to causing invalid test "
+    "behavior."
+)
+B101.methods = {
+    "assert_calls",
+    "assert_not_called",
+    "assert_called",
+    "assert_called_once",
+    "not_called",
+    "called_once",
+    "called_once_with",
+}
+
+B102 = Error(message=u"B102: Missing `from __future__ import absolute_import`")
 
 # Those could be false positives but it's more dangerous to let them slip
 # through if they're not.
-B301 = partial(
-    error,
-    message="B301: Python 3 does not include .iter* methods on dictionaries. "
-    "Use `six.iter*` or `future.utils.iter*` instead.",
-    type=SentryCheck,
+B301 = Error(
+    message=u"B301: Python 3 does not include .iter* methods on dictionaries. "
+    "Use `six.iter*` or `future.utils.iter*` instead."
 )
-B301.methods = {'iterkeys', 'itervalues', 'iteritems', 'iterlists'}
-B301.valid_paths = {'six', 'future.utils', 'builtins'}
+B301.methods = {"iterkeys", "itervalues", "iteritems", "iterlists"}
+B301.valid_paths = {"six", "future.utils", "builtins"}
 
-B302 = partial(
-    error,
-    message="B302: Python 3 does not include .view* methods on dictionaries. "
+B302 = Error(
+    message=u"B302: Python 3 does not include .view* methods on dictionaries. "
     "Remove the ``view`` prefix from the method name. Use `six.view*` "
-    "or `future.utils.view*` instead.",
-    type=SentryCheck,
+    "or `future.utils.view*` instead."
 )
-B302.methods = {'viewkeys', 'viewvalues', 'viewitems', 'viewlists'}
-B302.valid_paths = {'six', 'future.utils', 'builtins'}
+B302.methods = {"viewkeys", "viewvalues", "viewitems", "viewlists"}
+B302.valid_paths = {"six", "future.utils", "builtins"}
 
-B303 = partial(
-    error,
-    message="B303: __metaclass__ does not exist in Python 3. Use "
-    "use `@six.add_metaclass()` instead.",
-    type=SentryCheck,
+B303 = Error(
+    message=u"B303: __metaclass__ does not exist in Python 3. Use "
+    "use `@six.add_metaclass()` instead."
 )
 
-B304 = partial(
-    error,
-    message="B304: sys.maxint does not exist in Python 3. Use `sys.maxsize`.",
-    type=SentryCheck,
-)
+B304 = Error(message=u"B304: sys.maxint does not exist in Python 3. Use `sys.maxsize`.")
 
-B305 = partial(
-    error,
-    message="B305: .next() does not exist in Python 3. Use ``six.next()`` "
-    "instead.",
-    type=SentryCheck,
+B305 = Error(
+    message=u"B305: .next() does not exist in Python 3. Use ``six.next()`` " "instead."
 )
-B305.methods = {'next'}
-B305.valid_paths = {'six', 'future.utils', 'builtins'}
+B305.methods = {"next"}
+B305.valid_paths = {"six", "future.utils", "builtins"}
 
-B306 = partial(
-    error,
-    message="B306: ``BaseException.message`` has been deprecated as of Python "
+B306 = Error(
+    message=u"B306: ``BaseException.message`` has been deprecated as of Python "
     "2.6 and is removed in Python 3. Use ``str(e)`` to access the "
     "user-readable message. Use ``e.args`` to access arguments passed "
-    "to the exception.",
-    type=SentryCheck,
+    "to the exception."
 )
 
-B307 = partial(
-    error,
-    message="B307: Python 3 has combined urllib, urllib2, and urlparse into "
+B307 = Error(
+    message=u"B307: Python 3 has combined urllib, urllib2, and urlparse into "
     "a single library. For Python 2 compatibility, utilize the "
-    "six.moves.urllib module.",
-    type=SentryCheck
+    "six.moves.urllib module."
 )
-B307.names = {'urllib', 'urlib2', 'urlparse'}
+B307.names = {"urllib", "urlib2", "urlparse"}
 
-B308 = partial(
-    error,
-    message="B308: The usage of ``str`` differs between Python 2 and 3. Use "
-    "``six.binary_type`` instead.",
-    type=SentryCheck,
+B308 = Error(
+    message=u"B308: The usage of ``str`` differs between Python 2 and 3. Use "
+    "``six.binary_type`` instead."
 )
-B308.names = {'str'}
+B308.names = {"str"}
 
-B309 = partial(
-    error,
-    message="B309: ``unicode`` does not exist in Python 3. Use "
-    "``six.text_type`` instead.",
-    type=SentryCheck,
+B309 = Error(
+    message=u"B309: ``unicode`` does not exist in Python 3. Use "
+    "``six.text_type`` instead."
 )
-B309.names = {'unicode'}
+B309.names = {"unicode"}
 
-B310 = partial(
-    error,
-    message="B310: ``basestring`` does not exist in Python 3. Use "
-    "``six.string_types`` instead.",
-    type=SentryCheck,
+B310 = Error(
+    message=u"B310: ``basestring`` does not exist in Python 3. Use "
+    "``six.string_types`` instead."
 )
-B310.names = {'basestring'}
+B310.names = {"basestring"}
 
-B311 = partial(
-    error,
-    message="B311: ``long`` should not be used. Use int instead, and allow "
-    "Python to deal with handling large integers.",
-    type=SentryCheck,
+B311 = Error(
+    message=u"B311: ``long`` should not be used. Use int instead, and allow "
+    "Python to deal with handling large integers."
 )
-B311.names = {'long'}
+B311.names = {"long"}
 
-B312 = partial(
-    error,
-    message="B312: ``cgi.escape`` and ``html.escape`` should not be used. Use "
-    "sentry.utils.html.escape instead.",
-    type=SentryCheck,
+B312 = Error(
+    message=u"B312: ``cgi.escape`` and ``html.escape`` should not be used. Use "
+    "sentry.utils.html.escape instead."
 )
-B312.methods = {'escape'}
-B312.invalid_paths = {'cgi', 'html'}
+B312.methods = {"escape"}
+B312.invalid_paths = {"cgi", "html"}
 
-B313 = partial(
-    error,
-    message="B313: ``__unicode__`` should not be defined on classes. Define "
+B313 = Error(
+    message=u"B313: ``__unicode__`` should not be defined on classes. Define "
     "just ``__str__`` returning a unicode text string, and use the "
-    "sentry.utils.compat.implements_to_string class decorator.",
-    type=SentryCheck,
+    "sentry.utils.compat.implements_to_string class decorator."
 )
 
-B314 = partial(
-    error,
-    message="B314: print functions or statements are not allowed.",
-    type=SentryCheck,
-)
+B314 = Error(message=u"B314: print functions or statements are not allowed.")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[bdist_wheel]
+python-tag = py27
+
+[flake8]
+ignore = E203, E302, E501
+max-line-length = 100
+max-complexity = 12
+select = B,C,E,F,W,B9
+exclude = tests/b*
+
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,10 @@ setup(
     description="Sentry's custom flake8 checker plugin.",
     license="Apache 2.0",
     url="https://github.com/getsentry/sentry-flake8",
-    author='Sentry',
-    author_email='hello@sentry.io',
-    install_requires=[
-        "flake8>=3.5.0,<3.6.0",
-    ],
-    py_modules=['sentry_check'],
-    entry_points={
-        "flake8.extension": [
-            "B = sentry_check:SentryCheck",
-        ]
-    },
+    author="Sentry",
+    author_email="hello@sentry.io",
+    install_requires=["flake8>=3.5.0,<3.6.0"],
+    test_requires=["pytest"],
+    py_modules=["sentry_check"],
+    entry_points={"flake8.extension": ["B = sentry_check:SentryCheck"]},
 )

--- a/tests/b001.py
+++ b/tests/b001.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+try:
+    import something
+except:
+    # should be except ImportError:
+    import something_else as something
+
+try:
+    pass
+except ValueError:
+    # no warning here, all good
+    pass
+
+try:
+    pass
+except (KeyError, IndexError):
+    # no warning here, all good
+    pass
+
+try:
+    pass
+except BaseException as be:
+    # no warning here, all good
+    pass
+
+try:
+    pass
+except BaseException:
+    # no warning here, all good
+    pass
+
+
+def func(**kwargs):
+    try:
+        is_debug = kwargs["debug"]
+    except:
+        # should be except KeyError:
+        return
+
+    results = something.call(debug=is_debug)
+    try:
+        results["ok"]
+    except:  # noqa
+        # warning silenced
+        return

--- a/tests/b002.py
+++ b/tests/b002.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+
+def this_is_all_fine(n):
+    x = n + 1
+    y = 1 + n
+    z = +x + y
+    return +z
+
+
+def this_is_buggy(n):
+    x = ++n
+    return x
+
+
+def this_is_buggy_too(n):
+    return ++n

--- a/tests/b003.py
+++ b/tests/b003.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from os import environ
+import os
+
+
+os.environ = {}
+environ = {}  # that's fine, assigning a new meaning to the module-level name
+
+
+class Object:
+    os = None
+
+
+o = Object()
+o.os.environ = {}

--- a/tests/b004.py
+++ b/tests/b004.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+import sys
+
+
+def this_is_a_bug():
+    o = object()
+    if hasattr(o, "__call__"):
+        sys.stdout.write("Ooh, callable! Or is it?\n")
+    if getattr(o, "__call__", False):
+        sys.stdout.write("Ooh, callable! Or is it?\n")
+
+
+def this_is_fine():
+    o = object()
+    if callable(o):
+        sys.stdout.write("Ooh, this is actually callable.\n")

--- a/tests/b005.py
+++ b/tests/b005.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+s = "qwe"
+s.strip(s)  # no warning
+s.strip("we")  # no warning
+s.strip(".facebook.com")  # warning
+s.strip("e")  # no warning
+s.strip("\n\t ")  # no warning
+s.strip(r"\n\t ")  # warning
+s.lstrip(s)  # no warning
+s.lstrip("we")  # no warning
+s.lstrip(".facebook.com")  # warning
+s.lstrip("e")  # no warning
+s.lstrip("\n\t ")  # no warning
+s.lstrip(r"\n\t ")  # warning
+s.rstrip(s)  # no warning
+s.rstrip("we")  # warning
+s.rstrip(".facebook.com")  # warning
+s.rstrip("e")  # no warning
+s.rstrip("\n\t ")  # no warning
+s.rstrip(r"\n\t ")  # warning
+
+from somewhere import strip, other_type
+
+strip("we")  # no warning
+other_type().lstrip()  # no warning
+other_type().rstrip(["a", "b", "c"])  # no warning
+other_type().strip("a", "b")  # no warning

--- a/tests/b006_b008.py
+++ b/tests/b006_b008.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+
+import collections
+import logging
+import time
+
+
+def this_is_okay(value=(1, 2, 3)):
+    pass
+
+
+def and_this_also(value=tuple()):
+    pass
+
+
+def this_is_wrong(value=[1, 2, 3]):
+    pass
+
+
+def this_is_also_wrong(value={}):
+    pass
+
+
+def and_this(value=set()):
+    pass
+
+
+def this_too(value=collections.OrderedDict()):
+    pass
+
+
+# async def async_this_too(value=collections.OrderedDict()):
+#     pass
+
+
+def do_this_instead(value=None):
+    if value is None:
+        value = set()
+
+
+def in_fact_all_calls_are_wrong(value=time.time()):
+    pass
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def do_this_instead_of_calls_in_defaults(logger=LOGGER):
+    # That makes it more obvious that this one value is reused.
+    pass
+
+# def kwonlyargs_immutable(*, value=()):
+#     pass
+
+# def kwonlyargs_mutable(*, value=[]):
+#     pass

--- a/tests/b007.py
+++ b/tests/b007.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+import sys
+
+for i in range(10):
+    sys.stdout.write(i)
+
+sys.stdout.write(i)  # name no longer defined on Python 3; no warning yet
+
+for i in range(10):  # name not used within the loop; B007
+    sys.stdout.write(10)
+
+sys.stdout.write(i)  # name no longer defined on Python 3; no warning yet
+
+
+for _ in range(10):  # _ is okay for a throw-away variable
+    sys.stdout.write(10)
+
+
+for i in range(10):
+    for j in range(10):
+        for k in range(10):  # k not used, i and j used transitively
+            sys.stdout.write(i + j)
+
+
+def strange_generator():
+    for i in range(10):
+        for j in range(10):
+            for k in range(10):
+                for l in range(10):
+                    yield i, (j, (k, l))
+
+
+for i, (j, (k, l)) in strange_generator():  # i, k not used
+    sys.stdout.write(j, l)

--- a/tests/b009_b010.py
+++ b/tests/b009_b010.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+# Valid getattr usage
+getattr(foo, bar)
+getattr(foo, "bar", None)
+getattr(foo, "bar{foo}".format(foo="a"), None)
+getattr(foo, "bar{foo}".format(foo="a"))
+getattr(foo, bar, None)
+
+# Invalid usage
+getattr(foo, "bar")
+
+# Valid setattr usage
+setattr(foo, bar, None)
+setattr(foo, "bar{foo}".format(foo="a"), None)
+
+# Invalid usage
+setattr(foo, "bar", None)

--- a/tests/b101.py
+++ b/tests/b101.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+class A:
+    def assert_called_once(self):
+        pass
+
+
+A().assert_called_once()

--- a/tests/b102.py
+++ b/tests/b102.py
@@ -1,0 +1,3 @@
+import sys
+
+constant = sys.size

--- a/tests/b301_b302_b305.py
+++ b/tests/b301_b302_b305.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+
+import builtins  # future's builtins really
+import future.utils
+import six
+from six import iterkeys
+from future.utils import itervalues
+
+
+def this_is_okay():
+    d = {}
+    iterkeys(d)
+    six.iterkeys(d)
+    six.itervalues(d)
+    six.iteritems(d)
+    six.iterlists(d)
+    six.viewkeys(d)
+    six.viewvalues(d)
+    six.viewlists(d)
+    itervalues(d)
+    future.utils.iterkeys(d)
+    future.utils.itervalues(d)
+    future.utils.iteritems(d)
+    future.utils.iterlists(d)
+    future.utils.viewkeys(d)
+    future.utils.viewvalues(d)
+    future.utils.viewlists(d)
+    six.next(d)
+    builtins.next(d)
+
+
+def everything_else_is_wrong():
+    d = None  # note: bugbear is no type checker
+    d.iterkeys()
+    d.itervalues()
+    d.iteritems()
+    d.iterlists()  # Djangoism
+    d.viewkeys()
+    d.viewvalues()
+    d.viewitems()
+    d.viewlists()  # Djangoism
+    d.next()
+    d.keys().next()

--- a/tests/b303_b304.py
+++ b/tests/b303_b304.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+import sys
+import something_else
+
+
+def this_is_okay():
+    something_else.maxint
+    maxint = 3
+    maxint
+
+
+maxint = 3
+
+
+def this_is_also_okay():
+    maxint
+
+
+class CustomClassWithBrokenMetaclass:
+    __metaclass__ = type
+    maxint = 5  # this is okay
+    # the following shouldn't crash
+    (a, b, c) = list(range(3))
+    # it's different than this
+    a, b, c = list(range(3))
+    a, b, c, = list(range(3))
+    # and different than this
+    (a, b), c = list(range(3))
+    # a, *b, c = [1, 2, 3, 4, 5]
+    b[1:3] = [0, 0]
+
+    def this_is_also_fine(self):
+        self.maxint
+
+
+def this_is_wrong():
+    sys.maxint

--- a/tests/b306.py
+++ b/tests/b306.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+
+import sys
+
+try:
+    import some_library
+except ImportError as e:
+    foo = e.message
+else:
+    foo = some_library.message

--- a/tests/b314.py
+++ b/tests/b314.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+print("print statements are not allowed")

--- a/tests/test_sentry_check.py
+++ b/tests/test_sentry_check.py
@@ -1,0 +1,166 @@
+from __future__ import absolute_import
+
+import os
+import subprocess
+import unittest
+
+from sentry_check import (
+    B001,
+    B002,
+    B003,
+    B004,
+    B005,
+    B006,
+    B007,
+    B008,
+    B009,
+    B010,
+    B101,
+    B102,
+    B301,
+    B302,
+    B303,
+    B304,
+    B305,
+    B306,
+    B314,
+    SentryCheck,
+)
+
+
+def path(*paths):
+    return os.path.join(os.path.dirname(__file__), *paths)
+
+
+class SentryCheckTestCase(unittest.TestCase):
+    maxDiff = None
+
+    def errors(self, *errors):
+        return [SentryCheck.adapt_error(e) for e in errors]
+
+    def test_b001(self):
+        bbc = SentryCheck(filename=path("b001.py"))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B001(5, 0), B001(37, 4)))
+
+    def test_b002(self):
+        bbc = SentryCheck(filename=path("b002.py"))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B002(12, 8), B002(17, 11)))
+
+    def test_b003(self):
+        bbc = SentryCheck(filename=path("b003.py"))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B003(7, 0)))
+
+    def test_b004(self):
+        bbc = SentryCheck(filename=path("b004.py"))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B004(8, 7), B004(10, 7)))
+
+    def test_b005(self):
+        bbc = SentryCheck(filename=path("b005.py"))
+        errors = list(bbc.run())
+        self.assertEqual(
+            errors,
+            self.errors(
+                B005(6, 0),
+                B005(9, 0),
+                B005(12, 0),
+                B005(15, 0),
+                B005(18, 0),
+                B005(21, 0),
+            ),
+        )
+
+    def test_b006_b008(self):
+        bbc = SentryCheck(filename=path("b006_b008.py"))
+        errors = list(bbc.run())
+        self.assertEqual(
+            errors,
+            self.errors(
+                B006(16, 24),
+                B006(20, 29),
+                B006(24, 19),
+                B006(28, 19),
+                # B006(32, 31),
+                B008(41, 38),
+                # B006(55, 32),
+            ),
+        )
+
+    def test_b007(self):
+        bbc = SentryCheck(filename=path("b007.py"))
+        errors = list(bbc.run())
+        self.assertEqual(
+            errors,
+            self.errors(
+                B007(10, 4, vars=("i",)),
+                B007(22, 12, vars=("k",)),
+                B007(34, 4, vars=("i",)),
+                B007(34, 12, vars=("k",)),
+            ),
+        )
+
+    def test_b009_b010(self):
+        bbc = SentryCheck(filename=path("b009_b010.py"))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B009(11, 0), B010(18, 0)))
+
+    def test_b101(self):
+        bbc = SentryCheck(filename=path("b101.py"))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B101(8, 0, vars=("assert_called_once",))))
+
+    def test_b102(self):
+        bbc = SentryCheck(filename=path("b102.py"))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B102(1, 1)))
+
+    def test_b301_b302_b305(self):
+        bbc = SentryCheck(filename=path("b301_b302_b305.py"))
+        errors = list(bbc.run())
+        self.assertEqual(
+            errors,
+            self.errors(
+                B301(34, 4),
+                B301(35, 4),
+                B301(36, 4),
+                B301(37, 4),
+                B302(38, 4),
+                B302(39, 4),
+                B302(40, 4),
+                B302(41, 4),
+                B305(42, 4),
+                B305(43, 4),
+            ),
+        )
+
+    def test_b303_b304(self):
+        bbc = SentryCheck(filename=path("b303_b304.py"))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B303(21, 4), B304(38, 4)))
+
+    def test_b306(self):
+        bbc = SentryCheck(filename=path("b306.py"))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B306(8, 10)))
+
+    def test_b314(self):
+        bbc = SentryCheck(filename=path("b314.py"))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B314(3, 0)))
+
+    def test_selfclean_sentry_check(self):
+        stdout = subprocess.check_output(["flake8", path(os.pardir, "sentry_check.py")])
+        self.assertEqual(stdout, b"")
+        # self.assertEqual(proc.stderr, b"")
+
+    def test_selfclean_test_sentry_check(self):
+        stdout = subprocess.check_output(["flake8", path()])
+        self.assertEqual(stdout, b"")
+        # self.assertEqual(proc.stderr, b'')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds a number of new checks (outlined below) as well as a test suite covering most checks.

- Switch license to MIT and add attribution to bugbear
- Rename existing B003 to B102
- Add checks from Bugbear: B003-B009
- Add test suite (modeled off of bugbear)
- Add pre-commit configuration

New Checks:

**B003**: Assigning to ``os.environ`` doesn't clear the
environment.  Subprocesses are going to see outdated
variables, in disagreement with the current process.  Use
``os.environ.clear()`` or the ``env=``  argument to Popen.

**B004**: Using ``hasattr(x, '__call__')`` to test if ``x`` is callable
is unreliable.  If ``x`` implements custom ``__getattr__`` or its
``__call__`` is itself not callable, you might get misleading
results.  Use ``callable(x)`` for consistent results.

**B005**: Using ``.strip()`` with multi-character strings is misleading
the reader. It looks like stripping a substring. Move your
character set to a constant if this is deliberate. Use
``.replace()`` or regular expressions to remove string fragments.

**B006**: Do not use mutable data structures for argument defaults.  All
calls reuse one instance of that data structure, persisting changes
between them.

**B007**: Loop control variable not used within the loop body.  If this is
intended, start the name with an underscore.

**B008**: Do not perform calls in argument defaults.  The call is
performed only once at function definition time.  All calls to your
function will reuse the result of that definition-time call.  If this is
intended, assign the function call to a module-level variable and use
that variable as a default value.

**B009**: Do not call ``getattr(x, 'attr')``, instead use normal
property access: ``x.attr``. Missing a default to ``getattr`` will cause
an ``AttributeError`` to be raised for non-existent properties. There is
no additional safety in using ``getattr`` if you know the attribute name
ahead of time.

**B010**: Do not call ``setattr(x, 'attr', val)``, instead use normal
property access: ``x.attr = val``. There is no additional safety in
using ``setattr`` if you know the attribute name ahead of time.