### PR TITLE
Travis CI: Trusty is EOL and sudo: is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-sudo: false
 language: python
 cache: pip
 


### PR DESCRIPTION
The sudo: tag is now deprecated in Travis CI because sudo is _always_ available and it can not be turned off.

@joshuarli