### PR TITLE
feat: add a B315 to disallow the map, filter, and zip builtins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv
 __pycache__/
 build/
 dist/

--- a/sentry_check.py
+++ b/sentry_check.py
@@ -39,7 +39,7 @@ class SentryVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_UAdd(self, node):
-        trailing_nodes = list(map(type, self.node_window[-4:]))
+        trailing_nodes = list(map(type, self.node_window[-4:]))  # NOQA: B315
         if trailing_nodes == [ast.UnaryOp, ast.UAdd, ast.UnaryOp, ast.UAdd]:
             originator = self.node_window[-4]
             self.errors.append(B002(originator.lineno, originator.col_offset))
@@ -215,7 +215,7 @@ class SentryVisitor(ast.NodeVisitor):
     def check_for_b007(self, node):
         targets = NameFinder()
         targets.visit(node.target)
-        ctrl_names = set(filter(lambda s: not s.startswith("_"), targets.names))
+        ctrl_names = set(filter(lambda s: not s.startswith("_"), targets.names))  # NOQA: B315
         body = NameFinder()
         for expr in node.body:
             body.visit(expr)

--- a/sentry_check.py
+++ b/sentry_check.py
@@ -55,7 +55,7 @@ class SentryVisitor(ast.NodeVisitor):
                     self.has_absolute_import = True
                     break
 
-        if node.module == "six.moves":
+        if node.module == "sentry.utils.compat":
             for nameproxy in node.names:
                 if nameproxy.name in B315.names:
                     self.satisfies_B315_imports = True
@@ -487,8 +487,7 @@ B313 = Error(
 
 B314 = Error(message=u"B314: print functions or statements are not allowed.")
 
-# TODO: enforce wrapping in a list? Or, I could do that in compat, and replace all current six.moves with that.
 B315 = Error(
-    message=u"B315: {} is an iterable in Python 3. Use ``from six.moves import {}`` instead."
+    message=u"B315: {} is an iterable in Python 3. Use ``from sentry.utils.compat import {}`` instead."
 )
 B315.names = {"map", "filter", "zip"}

--- a/sentry_check.py
+++ b/sentry_check.py
@@ -6,7 +6,7 @@ from functools import partial
 
 import pycodestyle
 
-__version__ = "0.0.1"
+__version__ = "0.2.0"
 
 
 class SentryVisitor(ast.NodeVisitor):

--- a/tests/b315.py
+++ b/tests/b315.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+
+map(lambda _:_, range(10))
+filter(lambda: True, zip("foo"))

--- a/tests/test_sentry_check.py
+++ b/tests/test_sentry_check.py
@@ -151,6 +151,30 @@ class SentryCheckTestCase(unittest.TestCase):
         errors = list(bbc.run())
         self.assertEqual(errors, self.errors(B314(3, 0)))
 
+    def test_b315(self):
+        bbc = SentryCheck(filename=path("b315.py"))
+        errors = list(bbc.run())
+        assert errors == [
+            (
+                3,
+                0,
+                "B315: map is an iterable in Python 3. Use ``from sentry.utils.compat import map`` instead.",
+                SentryCheck,
+            ),
+            (
+                4,
+                0,
+                "B315: filter is an iterable in Python 3. Use ``from sentry.utils.compat import filter`` instead.",
+                SentryCheck,
+            ),
+            (
+                4,
+                21,
+                "B315: zip is an iterable in Python 3. Use ``from sentry.utils.compat import zip`` instead.",
+                SentryCheck,
+            ),
+        ]
+
     def test_selfclean_sentry_check(self):
         stdout = subprocess.check_output(["flake8", path(os.pardir, "sentry_check.py")])
         self.assertEqual(stdout, b"")


### PR DESCRIPTION
...and require them to be from sentry.utils.compat, which wraps the builtins in lists for py2/3 compatibility.

This (and a new 0.3.0 release) is required for https://github.com/getsentry/sentry/pull/17213.