### PR TITLE
feat: do not allow izip imported from itertools

### DIFF
--- a/tests/b316.py
+++ b/tests/b316.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+izip = 1
+izip = lambda _:_
+
+izip("foo")
+
+from itertools import izip
+
+izip
+
+# XXX: not smart enough to detect that this overrides the problem import
+# from sentry.utils.compat import zip as izip
+# izip

--- a/tests/test_sentry_check.py
+++ b/tests/test_sentry_check.py
@@ -175,6 +175,18 @@ class SentryCheckTestCase(unittest.TestCase):
             ),
         ]
 
+    def test_b316(self):
+        bbc = SentryCheck(filename=path("b316.py"))
+        errors = list(bbc.run())
+        assert errors == [
+            (
+                10,
+                0,
+                "B316: itertools.izip is not available in Python 3. Use ``from sentry.utils.compat import zip as izip`` instead.",
+                SentryCheck,
+            ),
+        ]
+
     def test_selfclean_sentry_check(self):
         stdout = subprocess.check_output(["flake8", path(os.pardir, "sentry_check.py")])
         self.assertEqual(stdout, b"")


### PR DESCRIPTION
I've fixed izips before, but [they're starting to trickle in again,](https://github.com/getsentry/sentry/pull/17281/files#diff-0bf8679f9d23cd760a86e38fdd39976cR3) so need a lint rule.

Gonna cut 0.3.1 after this.