### PR TITLE
fix: Stop this binary_type suggestion madness

### DIFF
--- a/src/sentry_check.py
+++ b/src/sentry_check.py
@@ -482,7 +482,8 @@ B307.names = {"urllib", "urlib2", "urlparse"}
 
 B308 = Error(
     message=u"B308: The usage of ``str`` differs between Python 2 and 3. Use "
-    "``six.binary_type`` instead."
+    "``six.text_type`` instead. If you actually need to represent bytes, "
+    "use ``six.binary_type``."
 )
 B308.names = {"str"}
 


### PR DESCRIPTION
Almost always we actually want to cast to a text type, NOT to bytes.