### PR TITLE
feat: disallow py2/3 compat __future__s, and test on 3.8 + 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
         python:
           - 3.6.10
           - 3.7.9
+          - 3.8.6
+          - 3.9.1
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
           - 3.6.10
           - 3.7.9
           - 3.8.6
-          - 3.9.1
+          - 3.9.0
     steps:
     - uses: actions/checkout@v2
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ test:
 	py.test
 
 build: clean test lint fmt
-	python setup.py sdist bdist_wheel --universal > /dev/null
+	pip install -U wheel
+	python setup.py sdist bdist_wheel > /dev/null
 
 clean:
 	rm -rf __pycache__/ build/ dist/ *.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ fmt:
 	python -m black .
 
 lint:
-	python -m flake8 --exclude .venv/ -- src/
+	python -m flake8
 
 test:
 	py.test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools>=40.2.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length=100
+target-version=['py36']

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ package_dir =
      = src
 
 [bdist_wheel]
+# We enforce python 3 specific minor version range in setup.py.
 python-tag = py3
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ ignore = E203, E302, E501, W503, C901
 max-line-length = 100
 max-complexity = 12
 select = B,C,E,F,W,B9
-exclude = tests/b*
+exclude = .venv/,tests/cases/b*
 
 [metadata]
 license_file = LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ package_dir =
      = src
 
 [bdist_wheel]
-python-tag = py36
+python-tag = py3
 
 [flake8]
 ignore = E203, E302, E501, W503, C901

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import sys
 
-if sys.version_info[:2] < (3, 6):
-    sys.exit("sentry-flake8 requires at least Python 3.6.")
+assert (3, 6, 0) <= sys.version_info < (3, 10, 0), "sentry-flake8 requires Python 3.6 - 3.9."
 
 from setuptools import setup  # noqa: e402
 
@@ -20,6 +19,7 @@ setup(
             "pytest==6.2.2",
         ]
     },
+    python_requires=">=3.6, <3.10",
     py_modules=["sentry_check"],
     entry_points={"flake8.extension": ["B = sentry_check:SentryCheck"]},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 import sys
+from setuptools import setup
 
 assert (3, 6, 0) <= sys.version_info < (3, 10, 0), "sentry-flake8 requires Python 3.6 - 3.9."
-
-from setuptools import setup  # noqa: e402
 
 setup(
     name="sentry-flake8",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 if sys.version_info[:2] < (3, 6):
     sys.exit("sentry-flake8 requires at least Python 3.6.")
 
-from setuptools import setup
+from setuptools import setup  # noqa: e402
 
 setup(
     name="sentry-flake8",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "tests": [
             "pytest==6.2.2",
         ]
-    },  # last 2.7 and 3.7 compat version
+    },
     py_modules=["sentry_check"],
     entry_points={"flake8.extension": ["B = sentry_check:SentryCheck"]},
     classifiers=[
@@ -27,6 +27,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development",
     ],
 )

--- a/src/sentry_check.py
+++ b/src/sentry_check.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import ast
 from collections import namedtuple
 from functools import partial
@@ -274,36 +272,36 @@ class SentryCheck(object):
 
 
 error = namedtuple("error", "lineno col message type vars")
-Error = partial(partial, error, message=u"", type=SentryCheck, vars=())
+Error = partial(partial, error, message="", type=SentryCheck, vars=())
 
 B001 = Error(
-    message=u"B001: Do not use bare `except:`, it also catches unexpected "
+    message="B001: Do not use bare `except:`, it also catches unexpected "
     "events like memory errors, interrupts, system exit, and so on.  "
     "Prefer `except Exception:`.  If you're sure what you're doing, "
     "be explicit and write `except BaseException:`."
 )
 
 B002 = Error(
-    message=u"B002: Python does not support the unary prefix increment. Writing "
+    message="B002: Python does not support the unary prefix increment. Writing "
     "++n is equivalent to +(+(n)), which equals n. You meant n += 1."
 )
 
 B003 = Error(
-    message=u"B003: Assigning to `os.environ` doesn't clear the environment. "
+    message="B003: Assigning to `os.environ` doesn't clear the environment. "
     "Subprocesses are going to see outdated variables, in disagreement "
     "with the current process. Use `os.environ.clear()` or the `env=` "
     "argument to Popen."
 )
 
 B004 = Error(
-    message=u"B004: Using `hasattr(x, '__call__')` to test if `x` is callable "
+    message="B004: Using `hasattr(x, '__call__')` to test if `x` is callable "
     "is unreliable. If `x` implements custom `__getattr__` or its "
     "`__call__` is itself not callable, you might get misleading "
     "results. Use `callable(x)` for consistent results."
 )
 
 B005 = Error(
-    message=u"B005: Using .strip() with multi-character strings is misleading "
+    message="B005: Using .strip() with multi-character strings is misleading "
     "the reader. It looks like stripping a substring. Move your "
     "character set to a constant if this is deliberate. Use "
     ".replace() or regular expressions to remove string fragments."
@@ -312,7 +310,7 @@ B005.methods = {"lstrip", "rstrip", "strip"}
 B005.valid_paths = {}
 
 B006 = Error(
-    message=u"B006: Do not use mutable data structures for argument defaults. "
+    message="B006: Do not use mutable data structures for argument defaults. "
     "All calls reuse one instance of that data structure, persisting "
     "changes between them."
 )
@@ -331,11 +329,11 @@ B006.mutable_calls = {
     "set",
 }
 B007 = Error(
-    message=u"B007: Loop control variable {!r} not used within the loop body. "
+    message="B007: Loop control variable {!r} not used within the loop body. "
     "If this is intended, start the name with an underscore."
 )
 B008 = Error(
-    message=u"B008: Do not perform calls in argument defaults. The call is "
+    message="B008: Do not perform calls in argument defaults. The call is "
     "performed only once at function definition time. All calls to your "
     "function will reuse the result of that definition-time call. If "
     "this is intended, assign the function call to a module-level "
@@ -343,16 +341,16 @@ B008 = Error(
 )
 B008.immutable_calls = {"tuple", "frozenset"}
 B009 = Error(
-    message=u"B009: Do not call getattr with a constant attribute value, "
+    message="B009: Do not call getattr with a constant attribute value, "
     "it is not any safer than normal property access."
 )
 B010 = Error(
-    message=u"B010: Do not call setattr with a constant attribute value, "
+    message="B010: Do not call setattr with a constant attribute value, "
     "it is not any safer than normal property access."
 )
 
 B101 = Error(
-    message=u"B101: Avoid using the {} mock call as it is "
+    message="B101: Avoid using the {} mock call as it is "
     "confusing and prone to causing invalid test "
     "behavior."
 )
@@ -367,15 +365,15 @@ B101.methods = {
 }
 
 B312 = Error(
-    message=u"B312: ``cgi.escape`` and ``html.escape`` should not be used. Use "
+    message="B312: ``cgi.escape`` and ``html.escape`` should not be used. Use "
     "sentry.utils.html.escape instead."
 )
 B312.methods = {"escape"}
 B312.invalid_paths = {"cgi", "html"}
 
-B314 = Error(message=u"B314: print functions or statements are not allowed.")
+B314 = Error(message="B314: print functions or statements are not allowed.")
 
-B317 = Error(message=u"B317: Use ``from sentry.utils import json`` instead.")
+B317 = Error(message="B317: Use ``from sentry.utils import json`` instead.")
 B317.modules = {"json", "simplejson"}
 B317.names = {
     "load",
@@ -387,4 +385,6 @@ B317.names = {
     "_default_encoder",
 }
 
-B318 = Error(message=f"B318: The following __future__ are not allowed: {', '.join(DISALLOWED_FUTURES)}")
+B318 = Error(
+    message=f"B318: The following __future__ are not allowed: {', '.join(DISALLOWED_FUTURES)}"
+)

--- a/tests/cases/b001.py
+++ b/tests/cases/b001.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 try:
     import something
 except:

--- a/tests/cases/b002.py
+++ b/tests/cases/b002.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-
 def this_is_all_fine(n):
     x = n + 1
     y = 1 + n

--- a/tests/cases/b003.py
+++ b/tests/cases/b003.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from os import environ
 import os
 

--- a/tests/cases/b004.py
+++ b/tests/cases/b004.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 
 

--- a/tests/cases/b005.py
+++ b/tests/cases/b005.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 s = "qwe"
 s.strip(s)  # no warning
 s.strip("we")  # no warning

--- a/tests/cases/b006_b008.py
+++ b/tests/cases/b006_b008.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import collections
 import logging
 import time

--- a/tests/cases/b007.py
+++ b/tests/cases/b007.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 
 for i in range(10):

--- a/tests/cases/b009_b010.py
+++ b/tests/cases/b009_b010.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 # Valid getattr usage
 getattr(foo, bar)
 getattr(foo, "bar", None)

--- a/tests/cases/b101.py
+++ b/tests/cases/b101.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-
 class A:
     def assert_called_once(self):
         pass

--- a/tests/cases/b314.py
+++ b/tests/cases/b314.py
@@ -1,3 +1,1 @@
-from __future__ import absolute_import
-
 print("print statements are not allowed")

--- a/tests/cases/b317.py
+++ b/tests/cases/b317.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 import simplejson
 from json import loads, load

--- a/tests/test_sentry_check.py
+++ b/tests/test_sentry_check.py
@@ -32,22 +32,22 @@ class SentryCheckTestCase(unittest.TestCase):
     def test_b001(self):
         bbc = SentryCheck(filename=path("b001.py"))
         errors = list(bbc.run())
-        self.assertEqual(errors, self.errors(B001(5, 0), B001(37, 4)))
+        self.assertEqual(errors, self.errors(B001(3, 0), B001(35, 4)))
 
     def test_b002(self):
         bbc = SentryCheck(filename=path("b002.py"))
         errors = list(bbc.run())
-        self.assertEqual(errors, self.errors(B002(12, 8), B002(17, 11)))
+        self.assertEqual(errors, self.errors(B002(9, 8), B002(14, 11)))
 
     def test_b003(self):
         bbc = SentryCheck(filename=path("b003.py"))
         errors = list(bbc.run())
-        self.assertEqual(errors, self.errors(B003(7, 0)))
+        self.assertEqual(errors, self.errors(B003(5, 0)))
 
     def test_b004(self):
         bbc = SentryCheck(filename=path("b004.py"))
         errors = list(bbc.run())
-        self.assertEqual(errors, self.errors(B004(8, 7), B004(10, 7)))
+        self.assertEqual(errors, self.errors(B004(6, 7), B004(8, 7)))
 
     def test_b005(self):
         bbc = SentryCheck(filename=path("b005.py"))
@@ -55,12 +55,12 @@ class SentryCheckTestCase(unittest.TestCase):
         self.assertEqual(
             errors,
             self.errors(
-                B005(6, 0),
-                B005(9, 0),
-                B005(12, 0),
-                B005(15, 0),
-                B005(18, 0),
-                B005(21, 0),
+                B005(4, 0),
+                B005(7, 0),
+                B005(10, 0),
+                B005(13, 0),
+                B005(16, 0),
+                B005(19, 0),
             ),
         )
 
@@ -70,13 +70,11 @@ class SentryCheckTestCase(unittest.TestCase):
         self.assertEqual(
             errors,
             self.errors(
-                B006(16, 24),
-                B006(20, 29),
-                B006(24, 19),
-                B006(28, 19),
-                # B006(32, 31),
-                B008(41, 38),
-                # B006(55, 32),
+                B006(14, 24),
+                B006(18, 29),
+                B006(22, 19),
+                B006(26, 19),
+                B008(39, 38),
             ),
         )
 
@@ -86,32 +84,44 @@ class SentryCheckTestCase(unittest.TestCase):
         self.assertEqual(
             errors,
             self.errors(
-                B007(10, 4, vars=("i",)),
-                B007(22, 12, vars=("k",)),
-                B007(34, 4, vars=("i",)),
-                B007(34, 12, vars=("k",)),
+                B007(8, 4, vars=("i",)),
+                B007(20, 12, vars=("k",)),
+                B007(32, 4, vars=("i",)),
+                B007(32, 12, vars=("k",)),
             ),
         )
 
     def test_b009_b010(self):
         bbc = SentryCheck(filename=path("b009_b010.py"))
         errors = list(bbc.run())
-        self.assertEqual(errors, self.errors(B009(11, 0), B010(18, 0)))
+        self.assertEqual(errors, self.errors(B009(9, 0), B010(16, 0)))
 
     def test_b101(self):
         bbc = SentryCheck(filename=path("b101.py"))
         errors = list(bbc.run())
-        self.assertEqual(errors, self.errors(B101(9, 0, vars=("assert_called_once",))))
+        self.assertEqual(errors, self.errors(B101(6, 0, vars=("assert_called_once",))))
 
     def test_b314(self):
         bbc = SentryCheck(filename=path("b314.py"))
         errors = list(bbc.run())
-        self.assertEqual(errors, self.errors(B314(3, 0)))
+        self.assertEqual(errors, self.errors(B314(1, 0)))
 
     def test_b317(self):
         bbc = SentryCheck(filename=path("b317.py"))
         errors = list(bbc.run())
         assert errors == [
+            (
+                1,
+                0,
+                "B317: Use ``from sentry.utils import json`` instead.",
+                SentryCheck,
+            ),
+            (
+                2,
+                0,
+                "B317: Use ``from sentry.utils import json`` instead.",
+                SentryCheck,
+            ),
             (
                 3,
                 0,
@@ -120,18 +130,6 @@ class SentryCheckTestCase(unittest.TestCase):
             ),
             (
                 4,
-                0,
-                "B317: Use ``from sentry.utils import json`` instead.",
-                SentryCheck,
-            ),
-            (
-                5,
-                0,
-                "B317: Use ``from sentry.utils import json`` instead.",
-                SentryCheck,
-            ),
-            (
-                6,
                 0,
                 "B317: Use ``from sentry.utils import json`` instead.",
                 SentryCheck,

--- a/tests/test_sentry_check.py
+++ b/tests/test_sentry_check.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 import subprocess
 import unittest


### PR DESCRIPTION
Supersedes https://github.com/getsentry/sentry-flake8/pull/17 now that I also added 3.8 and 3.9 testing.