### PR TITLE
feat: allow installation on newer pythons

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
-import sys
 from setuptools import setup
-
-assert (3, 6, 0) <= sys.version_info < (3, 10, 0), "sentry-flake8 requires Python 3.6 - 3.9."
 
 setup(
     name="sentry-flake8",
@@ -21,7 +18,7 @@ setup(
             "pytest==6.2.4",
         ]
     },
-    python_requires=">=3.6, <3.10",
+    python_requires=">=3.6",
     py_modules=["sentry_check"],
     entry_points={"flake8.extension": ["S = sentry_check:SentryCheck"]},
     classifiers=[


### PR DESCRIPTION
in general, there's no reason to limit the upper bound on python versions -- this makes it more difficult to adopt newer pythons down the line.  additionally the tests all pass on python3.10 right now!


<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
