### PR TITLE
feat: allow newer versions of flake8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author="Sentry",
     author_email="hello@sentry.io",
     install_requires=[
-        "flake8>=3.8.0,<3.10.0",
+        "flake8>=3.8.0",
         "flake8-bugbear==21.4.3",
     ],
     package_dir={"": "src"},


### PR DESCRIPTION
generally dependencies should only be upper bounded when there exists a known breakage.  additionally, this library works fine with flake8 4.x already.



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
